### PR TITLE
Add REACT_APP_LDS environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
 FROM node:11.9.0-alpine as builder
 WORKDIR /app
-COPY . ./
 RUN apk --no-cache add curl tar gzip bash git
-RUN yarn install
+
+# Dependency as another step to speed up build.
+COPY package.json yarn.lock ./
+RUN yarn
+
+# Actual build
+COPY . ./
+ENV REACT_APP_LDS "/lds"
 RUN yarn build
 
 FROM nginx:alpine
-COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+COPY docker/nginx.conf /etc/nginx/conf.d/default.conf.template
+COPY docker/start_nginx.sh /start_nginx.sh
 COPY --from=builder /app/build /usr/share/nginx/html
 EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["/bin/sh", "/start_nginx.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ COPY package.json yarn.lock ./
 RUN yarn
 
 # Actual build
-COPY . ./
+COPY ./src ./src
+COPY ./public ./public
 ENV REACT_APP_LDS "/lds"
 RUN yarn build
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,15 +1,19 @@
 server {
     listen       80;
     server_name  localhost;
-
-    location / {
-        root   /usr/share/nginx/html;
-        index  index.html index.htm;
-        try_files $uri /index.html;
-    }
-
+    root   /usr/share/nginx/html;
+    index  index.html index.htm;
     error_page   500 502 503 504  /50x.html;
+
+    try_files $uri /index.html;
+
     location = /50x.html {
         root   /usr/share/nginx/html;
+    }
+
+    location /lds {
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_pass ${REACT_APP_LDS};
     }
 }

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -11,7 +11,7 @@ server {
         root   /usr/share/nginx/html;
     }
 
-    location /lds {
+    location /lds/ {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_pass ${REACT_APP_LDS};

--- a/docker/start_nginx.sh
+++ b/docker/start_nginx.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+envsubst "`env | awk -F = '{printf \" \$%s\", \$1}'`" < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+exec nginx -g 'daemon off;'


### PR DESCRIPTION
The REACT_APP_LDS variable is used to create a proxy in the nginx
configuration. Be sure to set the variable with a trailing slash.

The build process also split the dependency install so the docker
cache is used.